### PR TITLE
Migrate to net8

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,7 @@
 <Project ToolsVersion="Current" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
     <PackageReference Include="Nerdbank.GitVersioning" Condition="!Exists('packages.config')">
-      <Version>3.5.119</Version>
+      <Version>3.6.146</Version>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
   </ItemGroup>

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ It's a beta version.
 
 - [ ] Additional spinners
 - [ ] More than 30 spinners
-- [ ] .NET 8 migration
+- [x] .NET 8 migration
 - [x] .NET 7 migration
 - [x] .NET 6 migration
 
@@ -62,8 +62,8 @@ Between the BODY tags edit the APP section so that it looks like this:
 ## Tech Stack
 
 - Blazor
-- .NET 6
-- C# 10.0
+- .NET 8
+- C# 12.0
 
 ## Run Locally
 

--- a/src/BlazorKit.Spinners.SampleWebAssembly/BlazorKit.Spinners.SampleWebAssembly.csproj
+++ b/src/BlazorKit.Spinners.SampleWebAssembly/BlazorKit.Spinners.SampleWebAssembly.csproj
@@ -1,18 +1,18 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.BlazorWebAssembly">
 
 	<PropertyGroup>
-		<TargetFramework>net7.0</TargetFramework>
+		<TargetFramework>net8.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="7.0.4" />
-		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="7.0.4" PrivateAssets="all" />
-		<PackageReference Include="Nerdbank.GitVersioning" Version="3.5.119">
+		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="8.0.10" />
+		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="8.0.10" PrivateAssets="all" />
+		<PackageReference Include="Nerdbank.GitVersioning" Version="3.6.146">
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 			<PrivateAssets>all</PrivateAssets>
 		</PackageReference>
-		<PackageReference Include="System.Net.Http.Json" Version="7.0.1" />
+		<PackageReference Include="System.Net.Http.Json" Version="8.0.1" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/BlazorKit.Spinners/BlazorKit.Spinners.csproj
+++ b/src/BlazorKit.Spinners/BlazorKit.Spinners.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
 	<PropertyGroup>
-		<TargetFramework>net7.0</TargetFramework>
+		<TargetFramework>net8.0</TargetFramework>
 		<StaticWebAssetsEnabled>false</StaticWebAssetsEnabled>
 		<Authors>Emanuele Bartolesi</Authors>
 		<Company>www.emanuelebartolesi.com</Company>
@@ -38,8 +38,8 @@
 		<None Include="wwwroot\keyframes.css" />
 		<None Include="wwwroot\spinners.css" />
 		<PackageReference Include="BlazorComponentUtilities" Version="1.8.0" />
-		<PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="7.0.4" />
-		<PackageReference Include="Nerdbank.GitVersioning" Version="3.5.119" />
+		<PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="8.0.10" />
+		<PackageReference Include="Nerdbank.GitVersioning" Version="3.6.146" />
 	</ItemGroup>
 
 </Project>


### PR DESCRIPTION
@kasuken this pull request includes several updates to migrate the project to .NET 8 and update various package versions. The most important changes include updating the target framework, modifying package references, and updating the README to reflect the new .NET version.

.NET 8 migration:

* [`src/BlazorKit.Spinners.SampleWebAssembly/BlazorKit.Spinners.SampleWebAssembly.csproj`](diffhunk://#diff-6f8451cf6b1f273ed1f32f272cbb4884b67d61cb9ecfea6ac6e6854776994372L4-R15): Updated the `TargetFramework` to `net8.0` and updated the versions of package references to match .NET 8.
* [`src/BlazorKit.Spinners/BlazorKit.Spinners.csproj`](diffhunk://#diff-b31539c850bd767ed3f5141383107ccd75b8d30f905f3508512eaa2d6e3d3845L4-R4): Updated the `TargetFramework` to `net8.0` and updated the versions of package references to match .NET 8. [[1]](diffhunk://#diff-b31539c850bd767ed3f5141383107ccd75b8d30f905f3508512eaa2d6e3d3845L4-R4) [[2]](diffhunk://#diff-b31539c850bd767ed3f5141383107ccd75b8d30f905f3508512eaa2d6e3d3845L41-R42)

Package version updates:

* [`Directory.Build.props`](diffhunk://#diff-9da24614831c308827a1ae533ffea392c97638c261dd42bd0f5226baa136d16eL5-R5): Updated `Nerdbank.GitVersioning` package version from `3.5.119` to `3.6.146`.

Documentation updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L28-R28): Updated the checklist to mark the .NET 8 migration as complete and updated the tech stack section to reflect the use of .NET 8 and C# 12.0. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L28-R28) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L66-R67)